### PR TITLE
Add Fishing System Script (ESX + ox_inventory compatible)

### DIFF
--- a/server-data/resources/[addons]/bpt_fishing/client/client.lua
+++ b/server-data/resources/[addons]/bpt_fishing/client/client.lua
@@ -1,0 +1,76 @@
+ESX = exports["es_extended"]:getSharedObject()
+
+local function notify(msg)
+    ESX.ShowNotification(msg)
+end
+
+-- Calcola zona d'acqua
+local function getWaterLevelType()
+    local coords = GetEntityCoords(PlayerPedId())
+    local foundWater, waterHeight = GetWaterHeight(coords.x, coords.y, coords.z)
+    if not foundWater then
+        return "low"
+    end
+    if waterHeight > 5.0 then
+        return "high"
+    elseif waterHeight > 1.5 then
+        return "medium"
+    else
+        return "low"
+    end
+end
+
+-- Registra i punti pesca con ox_target
+CreateThread(function()
+    for i, zone in ipairs(Config.FishingZones) do
+        exports.ox_target:addBoxZone({
+            coords = zone.coords,
+            size = vec3(2, 2, 2),
+            rotation = 0.0,
+            debug = false,
+            options = {
+                {
+                    label = TranslateCap(zone.name), -- Traduzione dinamica
+                    icon = zone.icon or "fa-solid fa-fish",
+                    onSelect = function()
+                        TriggerEvent("fishing:start")
+                    end,
+                },
+            },
+        })
+    end
+end)
+
+-- Evento pesca
+RegisterNetEvent("fishing:start", function()
+    ESX.TriggerServerCallback("fishing:canFish", function(canFish, msg)
+        if not canFish then
+            notify(msg)
+            return
+        end
+
+        notify(TranslateCap("start_fishing"))
+        TaskStartScenarioInPlace(PlayerPedId(), "world_human_stand_fishing", 0, true)
+
+        Wait(8000)
+        ClearPedTasks(PlayerPedId())
+
+        local zone = getWaterLevelType()
+        TriggerServerEvent("fishing:rewardFish", zone)
+    end)
+end)
+
+-- Crea i blip sulla mappa per ogni zona di pesca
+CreateThread(function()
+    for i, zone in ipairs(Config.FishingZones) do
+        local blip = AddBlipForCoord(zone.coords)
+        SetBlipSprite(blip, 68) -- Icona del blip (68 = pesce)
+        SetBlipDisplay(blip, 4)
+        SetBlipScale(blip, 0.8)
+        SetBlipColour(blip, 3) -- Colore verde acqua
+        SetBlipAsShortRange(blip, true)
+        BeginTextCommandSetBlipName("STRING")
+        AddTextComponentString(_U(zone.name)) -- Usa la traduzione
+        EndTextCommandSetBlipName(blip)
+    end
+end)

--- a/server-data/resources/[addons]/bpt_fishing/config.lua
+++ b/server-data/resources/[addons]/bpt_fishing/config.lua
@@ -1,0 +1,50 @@
+Config = {}
+
+Config.Locale = "it" -- oppure 'en'
+
+Config.RequiredItems = {
+    Rod = "fishing_rod",
+    Bait = "bait",
+}
+
+Config.FishList = {
+    { name = "tuna", chance = 10 },
+    { name = "salmon", chance = 15 },
+    { name = "trout", chance = 25 },
+    { name = "anchovy", chance = 30 },
+    { name = "plastic_bag", chance = 20 },
+}
+
+Config.WaterZones = {
+    ["low"] = 0.5,
+    ["medium"] = 0.75,
+    ["high"] = 1.0,
+}
+
+Config.FishingZones = {
+    {
+        coords = vector3(-1581.652710, 5201.644043, 3.971436),
+        icon = "fa-solid fa-fish",
+        name = "fishing_ocean",
+    },
+    {
+        coords = vector3(-1587.956055, 5216.571289, 3.988281),
+        icon = "fa-solid fa-water",
+        name = "fishing_ocean",
+    },
+    {
+        coords = vector3(1298.584595, 4215.692383, 33.896729),
+        icon = "fa-solid fa-water",
+        name = "fishing_lake",
+    },
+    {
+        coords = vector3(-285.534058, 6627.336426, 7.139160),
+        icon = "fa-solid fa-fish",
+        name = "fishing_ocean",
+    },
+    {
+        coords = vector3(33.191212, 855.560425, 197.727417),
+        icon = "fa-solid fa-water",
+        name = "fishing_lake",
+    },
+}

--- a/server-data/resources/[addons]/bpt_fishing/fxmanifest.lua
+++ b/server-data/resources/[addons]/bpt_fishing/fxmanifest.lua
@@ -1,0 +1,29 @@
+fx_version("cerulean")
+game("gta5")
+
+description("Script di pesca ricreativo - ESX + ox_inventory")
+author("BPTNetwork")
+version("1.0.0")
+
+-- File script
+client_scripts({
+    "config.lua",
+    "client/*.lua",
+})
+
+server_scripts({
+    "@oxmysql/lib/MySQL.lua",
+    "config.lua",
+    "server/*.lua",
+})
+
+shared_script({
+    "@es_extended/imports.lua",
+    "@es_extended/locale.lua",
+    "locales/*.lua",
+})
+
+dependencies({
+    "es_extended",
+    "ox_inventory",
+})

--- a/server-data/resources/[addons]/bpt_fishing/license
+++ b/server-data/resources/[addons]/bpt_fishing/license
@@ -1,0 +1,31 @@
+MIT License
+
+Copyright (c) 2025 BPTNetwork
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to:
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+📌 Contributing Notice:
+By submitting a contribution (code, documentation, or other materials), you agree
+to license your contribution under the same MIT License and allow it to be freely
+used within the BPTNetwork project and its derivatives. Contributions must comply
+with the coding and quality standards defined by the maintainers.
+
+📌 Attribution Notice:
+All original work must retain proper attribution to BPTNetwork. If this resource is
+included in a larger package, credit must be clearly visible in documentation or
+README.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/server-data/resources/[addons]/bpt_fishing/locales/en.lua
+++ b/server-data/resources/[addons]/bpt_fishing/locales/en.lua
@@ -1,0 +1,10 @@
+Locales["en"] = {
+    ["no_rod"] = "You need a fishing rod.",
+    ["no_bait"] = "You need bait to fish.",
+    ["start_fishing"] = "You started fishing...",
+    ["got_fish"] = "You caught: %s!",
+    ["got_trash"] = "You caught trash...",
+    ["target_label"] = "Start fishing",
+    ["fishing_ocean"] = "Fishing Spot - Ocean",
+    ["fishing_lake"] = "Fishing Spot - Lake",
+}

--- a/server-data/resources/[addons]/bpt_fishing/locales/it.lua
+++ b/server-data/resources/[addons]/bpt_fishing/locales/it.lua
@@ -1,0 +1,10 @@
+Locales["it"] = {
+    ["no_rod"] = "Ti serve una canna da pesca.",
+    ["no_bait"] = "Ti serve un'esca per pescare.",
+    ["start_fishing"] = "Hai iniziato a pescare...",
+    ["got_fish"] = "Hai pescato: %s!",
+    ["got_trash"] = "Hai pescato un rifiuto...",
+    ["target_label"] = "Inizia a pescare",
+    ["fishing_ocean"] = "Punto di Pesca - Oceano",
+    ["fishing_lake"] = "Punto di Pesca - Lago",
+}

--- a/server-data/resources/[addons]/bpt_fishing/readme.md
+++ b/server-data/resources/[addons]/bpt_fishing/readme.md
@@ -1,0 +1,54 @@
+# 🎣 bpt_fishing System for FiveM
+
+A lightweight and fully configurable fishing activity script for ESX-based FiveM servers.  
+Built with `ox_inventory` and `ox_target` support for an immersive and user-friendly experience.
+
+---
+
+## 📦 Features
+
+- ✅ Requires **fishing rod** and **bait** (customizable items)
+- 🌊 Players can fish at **designated fishing zones**
+- 📍 **Blips** shown on the map to locate fishing areas
+- 🐟 Fishable items: `tuna`, `salmon`, `trout`, `anchovy`, and `plastic_bag`
+- 🎯 Success chance varies by water density (low / medium / high)
+- 🌐 **Multilingual support** (`locales/en.lua`, `locales/it.lua`, etc.)
+- 🧱 Configurable via `config.lua`
+
+---
+
+## 📁 Dependencies
+
+- [ESX](https://github.com/esx-framework/esx-legacy)
+- [ox_inventory](https://github.com/overextended/ox_inventory)
+- [ox_target](https://github.com/overextended/ox_target)
+
+---
+
+## 🛠️ Installation
+
+1. Download or clone this repository into your `resources` folder.
+2. Add to your `server.cfg`:
+
+   ```cfg
+   ensure fishing
+
+['fishing_rod'] = {
+    label = 'Fishing Rod',
+    weight = 500,
+    stack = false,
+    close = true,
+    description = 'A sturdy fishing rod.'
+},
+['bait'] = {
+    label = 'Bait',
+    weight = 100,
+    stack = true,
+    close = true,
+    description = 'Bait to attract fish.'
+},
+['tuna'] = { label = 'Tuna', weight = 800 },
+['salmon'] = { label = 'Salmon', weight = 700 },
+['trout'] = { label = 'Trout', weight = 600 },
+['anchovy'] = { label = 'Anchovy', weight = 400 },
+['plastic_bag'] = { label = 'Plastic Bag', weight = 200 },

--- a/server-data/resources/[addons]/bpt_fishing/server/server.lua
+++ b/server-data/resources/[addons]/bpt_fishing/server/server.lua
@@ -1,0 +1,37 @@
+ESX = exports["es_extended"]:getSharedObject()
+
+ESX.RegisterServerCallback("fishing:canFish", function(source, cb)
+    local hasRod = exports.ox_inventory:Search(source, "count", Config.RequiredItems.Rod) > 0
+    local hasBait = exports.ox_inventory:Search(source, "count", Config.RequiredItems.Bait) > 0
+
+    if not hasRod then
+        cb(false, TranslateCap("no_rod"))
+        return
+    elseif not hasBait then
+        cb(false, TranslateCap("no_bait"))
+        return
+    end
+
+    cb(true)
+end)
+
+RegisterNetEvent("fishing:rewardFish", function(zone)
+    local src = source
+    exports.ox_inventory:RemoveItem(src, Config.RequiredItems.Bait, 1)
+
+    local factor = Config.WaterZones[zone] or 1.0
+    local totalChance = math.random(1, 100)
+
+    local accumulated = 0
+    for _, fish in ipairs(Config.FishList) do
+        accumulated = accumulated + (fish.chance * factor)
+        if totalChance <= accumulated then
+            exports.ox_inventory:AddItem(src, fish.name, 1)
+            TriggerClientEvent("esx:showNotification", src, TranslateCap("got_fish", fish.name))
+            return
+        end
+    end
+
+    exports.ox_inventory:AddItem(src, "plastic_bag", 1)
+    TriggerClientEvent("esx:showNotification", src, TranslateCap("got_trash"))
+end)


### PR DESCRIPTION
This pull request adds a new fishing activity system for ESX-based FiveM servers using `ox_inventory`. Players can fish at designated water zones using a fishing rod and bait. The system supports localized translations and includes support for `ox_target` and map blips.

### Features

- 🎣 Requires fishing rod and bait (items configurable)
- 🗺️ Fishing zones with blips on the map
- 🌊 Different fishing probability based on water density (low, medium, high)
- 🐟 Fishable items: tuna, salmon, trout, anchovy, plastic bag
- 🔄 Fully localized (supports multiple languages via `locales`)
- 🧠 Optimized and modular design

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

Fixes #[issue_no]
### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Does your submission pass tests?

**Please describe the changes this PR makes and why it should be merged:**


<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):